### PR TITLE
Added photo and template bio to invited speakers

### DIFF
--- a/2020/index.md
+++ b/2020/index.md
@@ -71,8 +71,9 @@ The 2nd NLP-OSS workshop will be co-located with the EMNLP 2020 conference.
 ## Invited Speakers
 
 <h3> Principles of Good Machine Learning Systems Design </h3>
-<h4> <strong><a href="https://huyenchip.com">Chip Huyen</a>, Snorkel AI / Stanford University</strong> </h4>
+<h3> <strong><a href="https://huyenchip.com">Chip Huyen</a>, Snorkel AI / Stanford University</strong> </h3>
 This talk covers what it means to operationalize Machine Learning (ML) models. It starts by analyzing the difference between ML in research vs. in production, ML systems vs. traditional software, as well as myths about ML production. It then goes over the principles of good ML systems design and introduces an iterative framework for ML systems design, from scoping the project, data management, model development, deployment, maintenance, to business analysis. It covers the differences between DataOps, ML Engineering, MLOps, and data science, and where each fits into the framework. The talk ends with a survey of the ML production ecosystem, the economics of open source, and open-core businesses.
+<br><br>
 <p>
 <img src="https://huyenchip.com/assets/profile.jpg" alt="Chip Huyen" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
 </p>
@@ -82,8 +83,9 @@ Learning Systems Design at Stanford. Previously, she was with Netflix, NVIDIA, P
 <br><br><br>
 
 <h3> On Typing: Historical and Potential Interactions in Word-processing </h3>
-<h4> <strong><a href="https://spencermounta.in/">Spencer Kelly</a>, Freelance Developer</strong> </h4>
+<h3> <strong><a href="https://spencermounta.in/">Spencer Kelly</a>, Freelance Developer</strong> </h3>
 People love typing, in a surprising and universal way. In this talk we look at the development of word-processing, and the design-decisions in this historic interface. Can NLP contribute to word-processing, without making it worse? What would a text-centered computer really look like? We look at the history of punctuation, keyboards, and markup languages. We look at Wikipedia, text-editors, and data structures - with the goal of authoring usable data in text.
+<br><br>
 <p>
 <img src="https://avatars2.githubusercontent.com/u/399657?s=460&u=afb7798f372f34b144511ebfd0895ccfef8c9536&v=4" alt="Spencer Kelly<" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
 </p>
@@ -92,8 +94,9 @@ People love typing, in a surprising and universal way. In this talk we look at t
 <br><br><br><br>
 
 <h3> An Introduction to Transfer Learning in NLP and HuggingFace </h3>
-<h4> <strong><a href="https://thomwolf.io/">Thomas Wolf</a>,  Huggingface</strong> </h4>
+<h3> <strong><a href="https://thomwolf.io/">Thomas Wolf</a>,  Huggingface</strong> </h3>
 In this talk I’ll start by introducing the recent breakthroughs in NLP that resulted from the combination of Transfer Learning schemes and Transformer architectures. The second part of the talk will be dedicated to an introduction of the open-source tools released by HuggingFace, in particular our Transformers, Tokenizers and Datasets libraries and our models.
+<br><br>
 <p>
 <img src="https://thomwolf.io/images/Thom_photo_circle.jpg" alt="Thomas Wolf<" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
 </p>

--- a/2020/index.md
+++ b/2020/index.md
@@ -5,7 +5,7 @@ layout: default
 
 # 2nd Workshop for Natural Language Processing Open Source Software (NLP-OSS) <br>
 
-### 11 or 12 Nov 2020 @ [EMNLP 2020](https://2020.emnlp.org/) 
+### 11 or 12 Nov 2020 @ [EMNLP 2020](https://2020.emnlp.org/)
 <br><br>
 
 With great scientific breakthrough comes solid engineering and open communities. The Natural Language Processing (NLP) community has benefited greatly from the open culture in sharing knowledge, data, and software. The primary objective of this workshop is to further the sharing of insights on the engineering and community aspects of creating, developing, and maintaining NLP open source software (OSS), which we seldom talk about in scientific publications. Our secondary goal is to promote synergies between different open source projects and encourage cross-software collaborations and comparisons.
@@ -69,9 +69,28 @@ The 2nd NLP-OSS workshop will be co-located with the EMNLP 2020 conference.
 
 ## Invited Speakers
 
-- [Chip Huyen](https://huyenchip.com), *TBD*
-- [Spencer Kelly](https://spencermounta.in/), Freelance Developer
-- [Thomas Wolf](https://thomwolf.io), Huggingface
+<h3> <strong><a href="https://huyenchip.com">Chip Huyen</a>, TBD</strong> </h3>
+<p>
+<img src="https://huyenchip.com/assets/profile.jpg" alt="Chip Huyen" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
+</p>
+<p> Chip Huyen is a writer and computer scientist. She works to bring the best engineering practices to machine learning research and production. She writes about culture, people, and tech. She's currently with a startup that focuses on the machine learning production pipeline in Silicon Valley. Previously, She was with NVIDIA, Netflix, Primer, Baomoi.com.</p>
+<br><br><br>
+
+<h3> <strong><a href="https://spencermounta.in/">Spencer Kelly</a>, Freelance Developer</strong> </h3>
+<p>
+<img src="https://avatars2.githubusercontent.com/u/399657?s=460&u=afb7798f372f34b144511ebfd0895ccfef8c9536&v=4" alt="Spencer Kelly<" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
+</p>
+<p> Spencer Kelly is a freelance developer. He is worried computers do not work very well and, things are a mess and software is in decline. If aliens ever land, we'll board their ship and discover that they have a better internet.</p>
+<br><br><br><br>
+
+<h3> <strong><a href="https://thomwolf.io/">Thomas Wolf</a>,  Huggingface</strong> </h3>
+<p>
+<img src="https://thomwolf.io/images/Thom_photo_circle.jpg" alt="Thomas Wolf<" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
+</p>
+<p>
+Thomas Wolf lead the Science Team at Huggingface Inc., a Brooklyn-based startup working on Natural Language Generation and Natural Language Understanding.
+</p>
+<br><br><br><br>
 
 ## Organizers
 

--- a/2020/index.md
+++ b/2020/index.md
@@ -70,27 +70,35 @@ The 2nd NLP-OSS workshop will be co-located with the EMNLP 2020 conference.
 
 ## Invited Speakers
 
-<h3> <strong><a href="https://huyenchip.com">Chip Huyen</a>, , Snorkel AI / Stanford University</strong> </h3>
+<h3> Principles of Good Machine Learning Systems Design </h3>
+<h4> <strong><a href="https://huyenchip.com">Chip Huyen</a>, Snorkel AI / Stanford University</strong> </h4>
+This talk covers what it means to operationalize Machine Learning (ML) models. It starts by analyzing the difference between ML in research vs. in production, ML systems vs. traditional software, as well as myths about ML production. It then goes over the principles of good ML systems design and introduces an iterative framework for ML systems design, from scoping the project, data management, model development, deployment, maintenance, to business analysis. It covers the differences between DataOps, ML Engineering, MLOps, and data science, and where each fits into the framework. The talk ends with a survey of the ML production ecosystem, the economics of open source, and open-core businesses.
 <p>
 <img src="https://huyenchip.com/assets/profile.jpg" alt="Chip Huyen" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
 </p>
-<p> Chip Huyen is an engineer who develops tools and best practices for machine learning production. She’s currently with Snorkel AI and she’ll be teaching Machine
+<h4> Bio </h4>
+<p>Chip Huyen is an engineer who develops tools and best practices for machine learning production. She’s currently with Snorkel AI and she’ll be teaching Machine
 Learning Systems Design at Stanford. Previously, she was with Netflix, NVIDIA, Primer. She’s also the author of four bestselling Vietnamese books.</p>
 <br><br><br>
 
-<h3> <strong><a href="https://spencermounta.in/">Spencer Kelly</a>, Freelance Developer</strong> </h3>
+<h3> On Typing: Historical and Potential Interactions in Word-processing </h3>
+<h4> <strong><a href="https://spencermounta.in/">Spencer Kelly</a>, Freelance Developer</strong> </h4>
+People love typing, in a surprising and universal way. In this talk we look at the development of word-processing, and the design-decisions in this historic interface. Can NLP contribute to word-processing, without making it worse? What would a text-centered computer really look like? We look at the history of punctuation, keyboards, and markup languages. We look at Wikipedia, text-editors, and data structures - with the goal of authoring usable data in text.
 <p>
 <img src="https://avatars2.githubusercontent.com/u/399657?s=460&u=afb7798f372f34b144511ebfd0895ccfef8c9536&v=4" alt="Spencer Kelly<" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
 </p>
-<p>Spencer Kelly is the author of <a href="http://compromise.cool/">compromise</a>, - a small natural language processing library for the browser. He is a web developer, and maintainer of open-source libraries. His background is in the semantic web and Wikipedia. Today his work focuses on creating infographics. His open-source work is funded by freelance web development. He is from Toronto, Canada.</p>
+<h4> Bio </h4>
+<p>Spencer Kelly is the author of <i><a href="http://compromise.cool/">compromise</a></i>, - a small natural language processing library for the browser. He is a web developer, and maintainer of open-source libraries. His background is in the semantic web and Wikipedia. Today his work focuses on creating infographics. His open-source work is funded by freelance web development. He is from Toronto, Canada.</p>
 <br><br><br><br>
 
-<h3> <strong><a href="https://thomwolf.io/">Thomas Wolf</a>,  Huggingface</strong> </h3>
+<h3> An Introduction to Transfer Learning in NLP and HuggingFace </h3>
+<h4> <strong><a href="https://thomwolf.io/">Thomas Wolf</a>,  Huggingface</strong> </h4>
+In this talk I’ll start by introducing the recent breakthroughs in NLP that resulted from the combination of Transfer Learning schemes and Transformer architectures. The second part of the talk will be dedicated to an introduction of the open-source tools released by HuggingFace, in particular our Transformers, Tokenizers and Datasets libraries and our models.
 <p>
 <img src="https://thomwolf.io/images/Thom_photo_circle.jpg" alt="Thomas Wolf<" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
 </p>
-<p>
-Thomas Wolf is co-founder and Chief Science Officer of HuggingFace. His team is on a mission to catalyze and democratize NLP research. Prior to HuggingFace, Thomas gained a Ph.D. in physics, and later a law degree. He worked as a physics researcher and a European Patent Attorney.
+<h4> Bio </h4>
+<p>Thomas Wolf is co-founder and Chief Science Officer of HuggingFace. His team is on a mission to catalyze and democratize NLP research. Prior to HuggingFace, Thomas gained a Ph.D. in physics, and later a law degree. He worked as a physics researcher and a European Patent Attorney.
 </p>
 <br><br><br><br>
 

--- a/2020/index.md
+++ b/2020/index.md
@@ -5,7 +5,8 @@ layout: default
 
 # 2nd Workshop for Natural Language Processing Open Source Software (NLP-OSS) <br>
 
-### 11 or 12 Nov 2020 @ EMNLP 2020 <br><br>
+### 11 or 12 Nov 2020 @ [EMNLP 2020](https://2020.emnlp.org/) 
+<br><br>
 
 With great scientific breakthrough comes solid engineering and open communities. The Natural Language Processing (NLP) community has benefited greatly from the open culture in sharing knowledge, data, and software. The primary objective of this workshop is to further the sharing of insights on the engineering and community aspects of creating, developing, and maintaining NLP open source software (OSS), which we seldom talk about in scientific publications. Our secondary goal is to promote synergies between different open source projects and encourage cross-software collaborations and comparisons.
 

--- a/2020/index.md
+++ b/2020/index.md
@@ -70,18 +70,19 @@ The 2nd NLP-OSS workshop will be co-located with the EMNLP 2020 conference.
 
 ## Invited Speakers
 
-<h3> <strong><a href="https://huyenchip.com">Chip Huyen</a>, TBD</strong> </h3>
+<h3> <strong><a href="https://huyenchip.com">Chip Huyen</a>, , Snorkel AI / Stanford University</strong> </h3>
 <p>
 <img src="https://huyenchip.com/assets/profile.jpg" alt="Chip Huyen" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
 </p>
-<p> Chip Huyen is a writer and computer scientist. She works to bring the best engineering practices to machine learning research and production. She writes about culture, people, and tech. She's currently with a startup that focuses on the machine learning production pipeline in Silicon Valley. Previously, She was with NVIDIA, Netflix, Primer, Baomoi.com.</p>
+<p> Chip Huyen is an engineer who develops tools and best practices for machine learning production. She’s currently with Snorkel AI and she’ll be teaching Machine
+Learning Systems Design at Stanford. Previously, she was with Netflix, NVIDIA, Primer. She’s also the author of four bestselling Vietnamese books.</p>
 <br><br><br>
 
 <h3> <strong><a href="https://spencermounta.in/">Spencer Kelly</a>, Freelance Developer</strong> </h3>
 <p>
 <img src="https://avatars2.githubusercontent.com/u/399657?s=460&u=afb7798f372f34b144511ebfd0895ccfef8c9536&v=4" alt="Spencer Kelly<" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
 </p>
-<p>Spencer Kelly is a freelance developer and author of <a href="http://compromise.cool/">compromise</a>, a nlp toolkit for the browser. He lives in Toronto, loves regular expressions, and wants the internet can be considerably better.</p>
+<p>Spencer Kelly is the author of <a href="http://compromise.cool/">compromise</a>, - a small natural language processing library for the browser. He is a web developer, and maintainer of open-source libraries. His background is in the semantic web and Wikipedia. Today his work focuses on creating infographics. His open-source work is funded by freelance web development. He is from Toronto, Canada.</p>
 <br><br><br><br>
 
 <h3> <strong><a href="https://thomwolf.io/">Thomas Wolf</a>,  Huggingface</strong> </h3>
@@ -89,7 +90,7 @@ The 2nd NLP-OSS workshop will be co-located with the EMNLP 2020 conference.
 <img src="https://thomwolf.io/images/Thom_photo_circle.jpg" alt="Thomas Wolf<" align="left" style="margin-right: 32px; margin-bottom: 16px;" width=160px height=159px >
 </p>
 <p>
-Thomas Wolf lead the Science Team at Huggingface Inc., a Brooklyn-based startup working on Natural Language Generation and Natural Language Understanding.
+Thomas Wolf is co-founder and Chief Science Officer of HuggingFace. His team is on a mission to catalyze and democratize NLP research. Prior to HuggingFace, Thomas gained a Ph.D. in physics, and later a law degree. He worked as a physics researcher and a European Patent Attorney.
 </p>
 <br><br><br><br>
 

--- a/_sass/_type.scss
+++ b/_sass/_type.scss
@@ -43,13 +43,13 @@ h3 {
   margin-top: 1.5rem;
   padding-top: 0;
   font-size: 1.25rem;
-  font-weight: lighter;
-  text-align: center;
 }
 
 h4, h5, h6 {
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   font-size: 1rem;
+  font-weight: lighter;
+  text-align: center;
 }
 
 p {


### PR DESCRIPTION
I've copied the raw rendered template of the 2018 page.

This PR renders an example: 

![image](https://user-images.githubusercontent.com/1050316/82614069-82181600-9bf9-11ea-8713-73b30e260489.png)
