### PR TITLE
Enabled proper dark mode

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -56,7 +56,11 @@ ul#navigation-list {
   list-style: none;
   padding-bottom: 0.75rem;
   padding-top: 0.45rem;
-  background: rgba(224, 214, 214, 1.0);
+  background: #33393d; //rgba(224, 214, 214, 1.0);
+
+      @media (prefers-color-scheme: dark) {
+        color: #33393d;
+      }
   }
   ul#navigation-list li {
     display: inline-block;
@@ -66,11 +70,18 @@ ul#navigation-list {
 	padding-left: 0;
     padding-right: 15px;
 	margin: auto;
-    background: rgba(224, 214, 214, 1.0);
+    background: #33393d; //rgba(224, 214, 214, 1.0);
+
+        @media (prefers-color-scheme: dark) {
+          color: #33393d;
+        }
 
     }
     ul#navigation-list li a {
-      color: #08503b;
+      color: #ffffff;
+
+          @media (prefers-color-scheme: dark) {
+            color: #24a37e;
+          }
     }
 }
-

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,7 +1,26 @@
 // Color scheme for light and dark modes.
 
-$light: #f76b48;
+$light: #2aabe4;
 $dark: #1ba77e;
+
+// Original noir		$light: #f76b48;
+//$light: #f76b48;		$dark: #1ba77e;
+//$dark: #1ba77e;
+
+// Millo Orange-Green theme.
+//$light: #ff5000;
+//$dark: #75aa5d;
+//$white: #ffffff;
+
+// Lemonstand Black-Blue theme.
+//$light: #2aabe4;
+//$dark: #33393d;
+//$white: #ffffff;
+
+// Loom Red-Bleu-Grey theme.
+//$light: #fe7860;
+//$dark: #506cf0;
+//$white: #ffffff;
 
 // Highlighting color for code block borders and language name.
 
@@ -28,3 +47,20 @@ $body-bg-dark: rgba(35, 35, 35, 1.0);
 $large-breakpoint: 38em;
 $large-font-size: 20px;
 $normal-font-size: 16px;
+
+// https://s3.amazonaws.com/ceblog/wp-content/uploads/2018/03/24214530/website-color-palettes-8.png
+$lemonstand-black:  #33393d;
+$lemonstand-yellow: #ffcd24;
+$lemonstand-blue:   #2aabe4;
+$lemonstand-lightblue: #9dc8e4;
+$lemonstand-grey:   #666b6e;
+
+
+//https://s3.amazonaws.com/ceblog/wp-content/uploads/2018/03/24214538/website-color-palettes-12.png
+$milloco-orange: #ff5000;
+$milloco-green:  #75aa5d;
+
+//https://s3.amazonaws.com/ceblog/wp-content/uploads/2018/03/24214506/website-color-palettes-1.png
+$loom-red: #fe7860;
+$loom-blue: #506cf0;
+$loom-grey: #a7c0cd;


### PR DESCRIPTION
Sorry for overlooking the dark mode. 

How about this color scheme? For `dark-mode`:

![image](https://user-images.githubusercontent.com/1050316/82808251-30eb7900-9ebc-11ea-9b6d-b07424187629.png)


And the original one for light mode:

![image](https://user-images.githubusercontent.com/1050316/82808320-59737300-9ebc-11ea-9d0f-27dd1010fcbb.png)
